### PR TITLE
Small vue-cli-3 fix allowing the backend pom file to copy the frontend static resources on project compilation

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -14,5 +14,6 @@ module.exports = {
   },
   // Change build paths to make them Maven compatible
   // see https://cli.vuejs.org/config/
-  outputDir: 'target/dist'
+  outputDir: 'target/dist',
+  assetsDir: 'static'
 }


### PR DESCRIPTION
I noticed that after compiling (`mvn clean install`), running the project (`--projects backend spring-boot:run`) and visiting http://localhost:8088 that a blank page was shown (even though running the frontend in a dev environment it works perfectly). It turns out that the backend `pom` file, which is instructed to copy assets from the `frontend/target/dist` and `frontend/target/dist/static` folders to the backend `resources` folder, only copies the index.html file and not the static assets. 
After the recent vue-cli-3 upgrade the static assets are no longer placed in the `frontend/target/dist/static` folder, thus adding `assetsDir: 'static'` to the `vue.config.js` file ensures the backend can copy the static assets upon compilation.