### PR TITLE
Support for JDK 8, 9 & 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: java
 jdk:
-- oraclejdk8
-script: mvn clean install jacoco:report coveralls:report
+  - oraclejdk8
+  - oraclejdk9
+  - oraclejdk11
+
+script: mvn clean install
+
 cache:
   directories:
   - node_modules
+
+after_success:
+  - mvn clean test jacoco:report coveralls:report

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 [![Coverage Status](https://coveralls.io/repos/github/jonashackt/spring-boot-vuejs/badge.svg?branch=master)](https://coveralls.io/github/jonashackt/spring-boot-vuejs?branch=master)
 [![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/jonashackt/spring-boot-vuejs/blob/master/LICENSE)
 [![versionspringboot](https://img.shields.io/badge/springboot-2.1.5_RELEASE-brightgreen.svg)](https://github.com/spring-projects/spring-boot)
-[![versionnodejs](https://img.shields.io/badge/nodejs-v11.14.0-brightgreen.svg)](https://nodejs.org/en/)
-[![versionvuejs](https://img.shields.io/badge/vue.js-2.6.10-brightgreen.svg)](https://vuejs.org/)
-[![versionvuecli](https://img.shields.io/badge/vue_CLI-3.8.2-brightgreen.svg)](https://cli.vuejs.org/)
-[![versionwebpack](https://img.shields.io/badge/webpack-4.28.4-brightgreen.svg)](https://webpack.js.org/)
+[![versionjava](https://img.shields.io/badge/jdk-8,_9,_11-brightgreen.svg?logo=java)](https://github.com/spring-projects/spring-boot)
+[![versionnodejs](https://img.shields.io/badge/nodejs-v11.14.0-brightgreen.svg?logo=node.js)](https://nodejs.org/en/)
+[![versionvuejs](https://img.shields.io/badge/vue.js-2.6.10-brightgreen.svg?logo=vue.js)](https://vuejs.org/)
+[![versionvuecli](https://img.shields.io/badge/vue_CLI-3.8.2-brightgreen.svg?logo=vue.js)](https://cli.vuejs.org/)
+[![versionwebpack](https://img.shields.io/badge/webpack-4.28.4-brightgreen.svg?logo=webpack)](https://webpack.js.org/)
 [![versionaxios](https://img.shields.io/badge/axios-0.18.0-brightgreen.svg)](https://github.com/axios/axios)
-[![versionjest](https://img.shields.io/badge/jest-23.6.0-brightgreen.svg)](https://jestjs.io/)
+[![versionjest](https://img.shields.io/badge/jest-23.6.0-brightgreen.svg?logo=jest)](https://jestjs.io/)
 [![versionnightwatch](https://img.shields.io/badge/nightwatch-0.9.21-brightgreen.svg)](http://nightwatchjs.org/)
 
 > **If you´re a JavaMagazin / blog.codecentric.de / Softwerker reader**, consider switching to [vue-cli-v2-webpack-v3](https://github.com/jonashackt/spring-boot-vuejs/tree/vue-cli-v2-webpack-v3)
@@ -1230,6 +1231,15 @@ Spring Boot handles the needed `maven.compiler.release`, which tell's Java from 
 
 We just set `1.8` as the baseline here, since if we set a newer version as the standard, builds on older versions then 8 will fail (see [this build log for example](https://travis-ci.org/jonashackt/spring-boot-vuejs/builds/547227298).
 
+Additionally, we use TravisCI to run the Maven build on some mayor Java versions - have a look into the [.travis.yml](.travis.yml):
+
+```
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - oraclejdk11
+```
 
 
 # Secure Spring Boot backend and protect Vue.js frontend

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This project is used as example in a variety of articles & as eBook:
 * [OMG! My package.json is so small - Vue CLI 3 Plugins](#omg-my-packagejson-is-so-small---vue-cli-3-plugins)
 * [The vue.config.js file](#the-vueconfigjs-file)
 * [Build and run with Docker](#build-and-run-with-docker)
+* [Run with JDK 8, 9 or 11ff](#run-with-jdk-8-9-or-11-ff)
 * [Secure Spring Boot backend and protect Vue.js frontend](#secure-spring-boot-backend-and-protect-vuejs-frontend)
 * [Secure the backend API with Spring Security](#secure-the-backend-api-with-spring-security)
 * [Configure Spring Security](#configure-spring-security)
@@ -1211,6 +1212,24 @@ $ docker logs 745e854d7781 --follow
 Now access your Dockerized Spring Boot powererd Vue.js app inside your Browser at [http://localhost:8088](http://localhost:8088). 
 
 If you have played enough with your Dockerized app, don't forget to stop (`docker stop 745e854d7781`) and remove (`docker rm 745e854d7781`) it in the end.
+
+
+# Run with JDK 8, 9 or 11 ff
+
+As with Spring Boot, we can define the desired Java version simply by editing our backend's [pom.xml](backend/pom.xml): 
+
+```
+	<properties>
+		<java.version>1.8</java.version>
+	</properties>
+```
+
+If you want to have `JDK9`, place a `<java.version>9</java.version>` or other versions just as you like to (see [this stackoverflow answer](https://stackoverflow.com/questions/54467287/how-to-specify-java-11-version-in-spring-spring-boot-pom-xml)).
+
+Spring Boot handles the needed `maven.compiler.release`, which tell's Java from version 9 on to build for a specific target.
+
+We just set `1.8` as the baseline here, since if we set a newer version as the standard, builds on older versions then 8 will fail (see [this build log for example](https://travis-ci.org/jonashackt/spring-boot-vuejs/builds/547227298).
+
 
 
 # Secure Spring Boot backend and protect Vue.js frontend

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This project is used as example in a variety of articles & as eBook:
 * [Last but not least: define getters for the vuex state](#last-but-not-least-define-getters-for-the-vuex-state)
 * [Use vuex Store inside the Login component and forward to Protected.vue, if Login succeeded](#use-vuex-store-inside-the-login-component-and-forward-to-protectedvue-if-login-succeeded)
 * [Redirect user from Protected.vue to Login.vue, if not authenticated before](#redirect-user-from-protectedvue-to-loginvue-if-not-authenticated-before)
+* [Check auth state at secured backend endpoints](#check-auth-state-at-secured-backend-endpoints)
 
 
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 
 		<!-- backend dependencies -->
 		<rest-assured.version>4.0.0</rest-assured.version>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>11</java.version>
+		<java.version>1.8</java.version>
 
 		<!-- backend dependencies -->
 		<rest-assured.version>4.0.0</rest-assured.version>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -12,7 +12,6 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
     	<frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
 	</properties>
 


### PR DESCRIPTION
This is much more a documentation issue, then a real configuration/code issue. Since we want to support multiple JDKs with the same source, we use Spring Boot's ability to manage the `maven.compiler.release` configuration (which itself then triggers the desired compile version from JDK9 on) with only the `<java.version>1.8</java.version>` property. If someone wants to use JDK9+ features, just tweak that property - but the project should work on all major versions now. TravisCI is now also configured to run on JDK8, 9 & 11 in parallel.

This also fixes https://github.com/jonashackt/spring-boot-vuejs/pull/37, which I'll close after merging this PR here, because it is not really mergable anymore.