### PR TITLE
Fixed issue with the regex for redirecting of frontend content

### DIFF
--- a/backend/src/main/java/de/jonashackt/springbootvuejs/controller/BackendController.java
+++ b/backend/src/main/java/de/jonashackt/springbootvuejs/controller/BackendController.java
@@ -54,7 +54,7 @@ public class BackendController {
 
     // Forwards all routes to FrontEnd except: '/', '/index.html', '/api', '/api/**'
     // Required because of 'mode: history' usage in frontend routing, see README for further details
-    @RequestMapping(value = "{_:^(?!index\\.html|api).$}")
+    @RequestMapping(value = "{_:^(?!index\\.html|api).*$}")
     public String redirectApi() {
         LOG.info("URL entered directly into the Browser, so we need to redirect...");
         return "forward:/";


### PR DESCRIPTION
Not having the `*` was causing frontend paths also being ignored.

See regex demo with `*` https://regexr.com/4oq28
See regex demo of original pattern https://regexr.com/4oq2b i.e. without `*`