### PR TITLE
Fix typo in the vue.config.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ module.exports = {
   ...
   // Change build paths to make them Maven compatible
   // see https://cli.vuejs.org/config/
-  outputDir;: 'target/dist',
-  assetsDir;: 'static';
+  outputDir: 'target/dist',
+  assetsDir: 'static'
 }
 ```
 


### PR DESCRIPTION
The README  is containing some types in the vue.config.js,  where some invalid semicolons are were present.