### PR TITLE
Fix tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -20,6 +20,7 @@
 		<!-- backend dependencies -->
 		<rest-assured.version>4.3.0</rest-assured.version>
 		<postgresql.version>42.2.12</postgresql.version>
+		<groovy.version>3.0.2</groovy.version>
 	</properties>
 
 	<dependencies>
@@ -40,6 +41,14 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<!-- The fixed groovy version is necessary after upgrade to Rest-Assured 4.3. because of conflicts otherwise
+		 see https://stackoverflow.com/questions/61020200/getting-java-lang-abstractmethoderror-when-i-test-using-rest-assured -->
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy</artifactId>
+			<version>${groovy.version}</version>
 		</dependency>
 
 		<!-- In-Memory database used for local development & testing -->

--- a/frontend/tests/unit/App.spec.js
+++ b/frontend/tests/unit/App.spec.js
@@ -7,6 +7,6 @@ describe('App component should', () => {
     const wrapper = shallowMount(App, {
       stubs: ['router-link', 'router-view']
     });
-    expect(wrapper.find('hello')).toBeDefined();
+    expect(wrapper.html()).toContain('<div id="nav">')
   });
 });


### PR DESCRIPTION
This fixes two test-related issues:

- After the upgrade to Rest-Assured 4.3. there were groovy conflicts which resulted in failing tests. The PR fixes this. Another possibility would be downgrading back to 4.2...
-  I also found an error in App.spec.js: "wrapper.find('hello')" always resulted in defined, even if you put a string in there, that is not present on the page... The proposed solution just checks for a html snippet instead.