### PR TITLE
Fixed forwarding from spring boot -> vuejs.

### DIFF
--- a/backend/src/main/java/de/jonashackt/springbootvuejs/controller/BackendController.java
+++ b/backend/src/main/java/de/jonashackt/springbootvuejs/controller/BackendController.java
@@ -51,13 +51,4 @@ public class BackendController {
         LOG.info("GET successfully called on /secured resource");
         return SECURED_TEXT;
     }
-
-    // Forwards all routes to FrontEnd except: '/', '/index.html', '/api', '/api/**'
-    // Required because of 'mode: history' usage in frontend routing, see README for further details
-    @RequestMapping(value = "{_:^(?!index\\.html|api).*$}")
-    public String redirectApi() {
-        LOG.info("URL entered directly into the Browser, so we need to redirect...");
-        return "forward:/";
-    }
-
 }

--- a/backend/src/main/java/de/jonashackt/springbootvuejs/controller/VueForwardController.java
+++ b/backend/src/main/java/de/jonashackt/springbootvuejs/controller/VueForwardController.java
@@ -1,0 +1,21 @@
+package de.jonashackt.springbootvuejs.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class VueForwardController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VueForwardController.class);
+
+    // Forwards all routes to FrontEnd except: '/', '/index.html', '/api', '/api/**'
+    // Required because of 'mode: history' usage in frontend routing, see README for further details
+    @RequestMapping(value = "{_:^(?!index\\.html|api).*$}")
+    public String redirectApi() {
+        LOG.info("URL entered directly into the Browser, so we need to redirect...");
+        return "forward:/";
+    }
+
+}


### PR DESCRIPTION
Forwarding from spring boot -> vuejs is currently busted.

Right now, it's handled inside the `BackendController` which is problematic because (a) it's a RestController and (b) it's only handling `/api/**` paths since it has a `RequestMapping` at the top of the class.

This PR introduces a `Controller` called VueForwardController whose only job is to properly handle the forwarding to the view app in case a user puts a full URL directly in the browser.