### PR TITLE
Fixed JDK versions and the OpenJDK distro suited to support that

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
       - run: mvn -B install --no-transfer-progress
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 8, 8.0.192, 11, 11.0.3, 17, 17.0.0+35 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
       - run: mvn -B install --no-transfer-progress
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8, 11, 16 ]
+        java-version: [ 8, 11, 17 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 16
+          java-version: 17
       - run: mvn -B verify --no-transfer-progress
 
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Having whatever is the latest JDK version (e.g., 11) as well as a specific version (e.g., 11.0.3), let's you ensure that when the latest version is red while the fixed version is green, that the problem is connected to the latest version specifically. Adopt is no more, Temurin is new and has few historical JDK minor versions, while Zulu has all of them, hence moving to Zulu as well.