### PR TITLE
Fix bug

### DIFF
--- a/frontend/src/views/Protected.vue
+++ b/frontend/src/views/Protected.vue
@@ -9,7 +9,7 @@
     <div v-if="securedApiCallSuccess">
       <span class="badge bg-success">API call</span> Full response: {{ backendResponse }} <span class="badge bg-success">successful</span>
     </div>
-    <div v-if="errors">
+    <div v-if="errors.length">
       <span class="badge bg-warning">API call</span> {{ errors }} <span class="badge bg-warning">NOT successful</span>
     </div>
   </div>


### PR DESCRIPTION
I think it might be better to change `v-if="errors"` to `v-if="errors.length"`, otherwise the message like "API call NOT successful" always shows up after logging in (you used v-if, so you do want it to show up conditionally, right?).
![Screenshot 2022-06-06 at 2 36 25 AM](https://user-images.githubusercontent.com/43973919/172065588-36fb31e5-2417-40b2-bbe7-6281b45103bf.png)
